### PR TITLE
Fix gain settings for multiple backends

### DIFF
--- a/airspy.c
+++ b/airspy.c
@@ -15,6 +15,7 @@
 
 #include <libairspy/airspy.h>
 
+#include "options.h"
 #include "airspy.h"
 #include "sdr.h"
 
@@ -127,7 +128,6 @@ void *airspy_backend_setup(uint64_t serial) {
      * Issue #15: previously the default was unreachable because the
      * global soapy_gain_val starts at 40, so the dB-mapping branch
      * always fired and produced 17 even when nothing was passed. */
-    extern int airspy_gain_val;
     extern int soapy_gain_explicit;
     int lg = 19;
     if (airspy_gain_val >= 0) {

--- a/bladerf.c
+++ b/bladerf.c
@@ -19,6 +19,7 @@
 
 #include <libbladeRF.h>
 
+#include "options.h"
 #include "sdr.h"
 #include "bladerf.h"
 
@@ -29,7 +30,6 @@ extern volatile sig_atomic_t running;
 extern pid_t self_pid;
 extern double samp_rate;
 extern double center_freq;
-extern int bladerf_gain_val;
 extern int bias_tee;
 extern int verbose;
 

--- a/options.c
+++ b/options.c
@@ -401,7 +401,7 @@ int options_parse(int argc, char **argv)
         case O_RATE:    opt_sample_rate    = (uint32_t)strtoul(optarg, NULL, 10); break;
         case O_GAIN: {
             double g = strtod(optarg, NULL);
-            soapy_gain_val = g; uhd_gain_db = g; bladerf_gain_db = (int)g;
+            soapy_gain_val = g; uhd_gain_db = g; bladerf_gain_db = (int)g; bladerf_gain_val = (int)g;
             rtl_gain_tenths_db = (int)(g * 10.0);
             sdrplay_gain_val = (int)g;
             airspy_lin_gain = (int)g;

--- a/options.c
+++ b/options.c
@@ -60,13 +60,11 @@ iq_format_t iq_format      = FMT_CI8;
 int   hackrf_lna_gain   = 0;
 int   hackrf_vga_gain   = 30;
 int   hackrf_amp_enable = 0;
-int   bladerf_gain_db   = 30;
-int   bladerf_gain_val  = 30;       /* alias used by bladerf.c */
+int   bladerf_gain_val  = 30;
 int   rtl_dev_index     = 0;
 int   rtl_gain_tenths_db = -1;
 int   agc_enabled       = 0;        /* used by rtlsdr.c */
-int   airspy_lin_gain   = -1;
-int   airspy_gain_val   = -1;       /* alias used by airspy.c */
+int   airspy_gain_val   = -1;
 char *sdrplay_serial    = NULL;
 int   sdrplay_gain_val  = 40;
 int   soapy_num         = -1;
@@ -80,8 +78,7 @@ char *soapy_setting_keys[SOAPY_SETTINGS_MAX];
 char *soapy_setting_vals[SOAPY_SETTINGS_MAX];
 int    soapy_setting_count = 0;
 char  *uhd_args         = NULL;
-double uhd_gain_db      = 40.0;
-int    usrp_gain_val    = 40;       /* alias used by usrp.c */
+int    usrp_gain_val    = 40;
 int    vita49_enabled   = 0;
 char  *vita49_endpoint  = NULL;
 
@@ -401,10 +398,10 @@ int options_parse(int argc, char **argv)
         case O_RATE:    opt_sample_rate    = (uint32_t)strtoul(optarg, NULL, 10); break;
         case O_GAIN: {
             double g = strtod(optarg, NULL);
-            soapy_gain_val = g; uhd_gain_db = g; bladerf_gain_db = (int)g; bladerf_gain_val = (int)g;
+            soapy_gain_val = g; bladerf_gain_val = (int)g; usrp_gain_val = (int)g;
             rtl_gain_tenths_db = (int)(g * 10.0);
             sdrplay_gain_val = (int)g;
-            airspy_lin_gain = (int)g;
+            airspy_gain_val = (int)g;
             /* HackRF: VGA covers 0..62 dB in 2 dB steps; LNA covers 0..40
              * in 8 dB steps. Map a single --gain knob across both, then
              * enable the 14 dB front-end amp above ~70 dB total. */

--- a/options.h
+++ b/options.h
@@ -18,126 +18,131 @@
 
 /* SDR backend selection -- one and only one of these is active per run. */
 typedef enum {
-    SDR_BACKEND_NONE = 0,
-    SDR_BACKEND_HACKRF,
-    SDR_BACKEND_BLADERF,
-    SDR_BACKEND_RTLSDR,
-    SDR_BACKEND_SOAPYSDR,
-    SDR_BACKEND_SDRPLAY,
-    SDR_BACKEND_AIRSPY,
-    SDR_BACKEND_USRP,
-    SDR_BACKEND_VITA49,
-    SDR_BACKEND_FILE,
+  SDR_BACKEND_NONE = 0,
+  SDR_BACKEND_HACKRF,
+  SDR_BACKEND_BLADERF,
+  SDR_BACKEND_RTLSDR,
+  SDR_BACKEND_SOAPYSDR,
+  SDR_BACKEND_SDRPLAY,
+  SDR_BACKEND_AIRSPY,
+  SDR_BACKEND_USRP,
+  SDR_BACKEND_VITA49,
+  SDR_BACKEND_FILE,
 } sdr_backend_t;
 
 typedef enum {
-    OP_MODE_DECODE = 0,        /* default: stare at standard grid + decode */
-    OP_MODE_SCAN,              /* off-grid LoRa discovery only */
-    OP_MODE_SCAN_AND_DECODE,   /* both: decode the grid, alert on off-grid */
+  OP_MODE_DECODE = 0,      /* default: stare at standard grid + decode */
+  OP_MODE_SCAN,            /* off-grid LoRa discovery only */
+  OP_MODE_SCAN_AND_DECODE, /* both: decode the grid, alert on off-grid */
 } op_mode_t;
 
 /* ---- Shared runtime state ---- */
 
-extern volatile sig_atomic_t running;  /* set to 0 by SIGINT/SIGTERM */
-extern double  samp_rate;              /* resolved sample rate (Hz, double for SDR APIs) */
-extern double  center_freq;            /* resolved center frequency (Hz) */
-extern int     bias_tee;
-extern double  ppm_correction;
+extern volatile sig_atomic_t running; /* set to 0 by SIGINT/SIGTERM */
+extern double samp_rate;   /* resolved sample rate (Hz, double for SDR APIs) */
+extern double center_freq; /* resolved center frequency (Hz) */
+extern int bias_tee;
+extern double ppm_correction;
 
 /* ---- Top-level user input ---- */
 
 extern sdr_backend_t opt_sdr_backend;
-extern char         *opt_sdr_serial;
-extern uint64_t      opt_center_freq_hz;  /* user override; 0 = derive from region */
-extern uint32_t      opt_sample_rate;     /* user override; 0 = SDR max */
-extern int           opt_clock_src;       /* CLOCK_SRC_* from sdr.h */
+extern char *opt_sdr_serial;
+extern uint64_t opt_center_freq_hz; /* user override; 0 = derive from region */
+extern uint32_t opt_sample_rate;    /* user override; 0 = SDR max */
+extern int opt_clock_src;           /* CLOCK_SRC_* from sdr.h */
 /* Log level: 0 = silent (warnings still go to stderr via warnx),
  *            1 = -v   INFO  (config, channel adds, frame decodes),
  *            2 = -vv  DEBUG (per-frame meta, decryption attempts),
  *            3 = -vvv TRACE (per-symbol state machine). */
-extern int           verbose;
-extern bool          opt_force_simd_generic;
-extern op_mode_t     opt_op_mode;
-extern bool          opt_alert_off_grid;
-extern bool          opt_list_devices;
-extern bool          opt_print_schema;
+extern int verbose;
+extern bool opt_force_simd_generic;
+extern op_mode_t opt_op_mode;
+extern bool opt_alert_off_grid;
+extern bool opt_list_devices;
+extern bool opt_print_schema;
 
 /* Meshtastic */
-extern char         *opt_region;          /* "US", "EU_868", ... */
-extern char         *opt_preset_csv;      /* "LongFast,LongSlow" or "all" */
-extern char         *opt_keys_csv;        /* user key list */
-extern char         *opt_keys_file;       /* path; one spec per line, # comments ok */
-extern char         *opt_share_url;       /* meshtastic.org/e/ URL to import at startup */
-extern char         *opt_iq_record;       /* path to write raw IQ to (tee from push_samples) */
-extern char         *opt_stats_json;      /* path to dump 5s per-channel stats JSON */
+extern char *opt_region;     /* "US", "EU_868", ... */
+extern char *opt_preset_csv; /* "LongFast,LongSlow" or "all" */
+extern char *opt_keys_csv;   /* user key list */
+extern char *opt_keys_file;  /* path; one spec per line, # comments ok */
+extern char *opt_share_url;  /* meshtastic.org/e/ URL to import at startup */
+extern char
+    *opt_iq_record; /* path to write raw IQ to (tee from push_samples) */
+extern char *opt_stats_json; /* path to dump 5s per-channel stats JSON */
 
 /* Extra user-supplied off-grid slots (e.g. promoted from scan). */
 #define EXTRA_FREQ_MAX 32
 typedef struct {
-    uint64_t freq_hz;
-    int      bw_hz;
-    int      sf;
-    int      cr;
+  uint64_t freq_hz;
+  int bw_hz;
+  int sf;
+  int cr;
 } extra_freq_t;
 extern extra_freq_t opt_extra_freqs[EXTRA_FREQ_MAX];
-extern int          opt_extra_freq_count;
+extern int opt_extra_freq_count;
 
 /* SDR / file input */
-extern char       *opt_input_file;       /* IQ file path for FILE backend */
-extern iq_format_t iq_format;            /* FMT_CI8 / FMT_CI16 / FMT_CF32 */
+extern char *opt_input_file;  /* IQ file path for FILE backend */
+extern iq_format_t iq_format; /* FMT_CI8 / FMT_CI16 / FMT_CF32 */
 
 /* Per-backend gain controls */
-extern int  hackrf_lna_gain;             /* 0..40 step 8 */
-extern int  hackrf_vga_gain;             /* 0..62 step 2 */
-extern int  hackrf_amp_enable;
-extern int  bladerf_gain_db;
-extern int  rtl_dev_index;
-extern int  rtl_gain_tenths_db;          /* tenths of dB; <0 = AGC */
-extern int  airspy_lin_gain;             /* 0..21; <0 = default */
+extern int hackrf_lna_gain; /* 0..40 step 8 */
+extern int hackrf_vga_gain; /* 0..62 step 2 */
+extern int hackrf_amp_enable;
+extern int bladerf_gain_val;
+extern int rtl_dev_index;
+extern int rtl_gain_tenths_db; /* tenths of dB; <0 = AGC */
+extern int airspy_gain_val;    /* 0..21; <0 = default */
 extern char *sdrplay_serial;
-extern int  sdrplay_gain_val;
-extern int  soapy_num;
+extern int sdrplay_gain_val;
+extern int soapy_num;
 extern char *soapy_args;
 #define SOAPY_GAINS_MAX 8
-extern char  *soapy_gain_elem_names[SOAPY_GAINS_MAX];
+extern char *soapy_gain_elem_names[SOAPY_GAINS_MAX];
 extern double soapy_gain_elem_vals[SOAPY_GAINS_MAX];
-extern int    soapy_gain_elem_count;
+extern int soapy_gain_elem_count;
 extern double soapy_gain_val;
-extern int    soapy_gain_explicit;
+extern int soapy_gain_explicit;
 #define SOAPY_SETTINGS_MAX 8
-extern char  *soapy_setting_keys[SOAPY_SETTINGS_MAX];
-extern char  *soapy_setting_vals[SOAPY_SETTINGS_MAX];
-extern int    soapy_setting_count;
-extern char  *uhd_args;
-extern double uhd_gain_db;
-extern int   vita49_enabled;
+extern char *soapy_setting_keys[SOAPY_SETTINGS_MAX];
+extern char *soapy_setting_vals[SOAPY_SETTINGS_MAX];
+extern int soapy_setting_count;
+extern char *uhd_args;
+extern int usrp_gain_val;
+extern int vita49_enabled;
 extern char *vita49_endpoint;
 
 /* Output sinks */
 #define FEED_MAX 4
 extern char *opt_feed_endpoint[FEED_MAX];
-extern int   opt_feed_count;
+extern int opt_feed_count;
 extern char *opt_mqtt_host;
-extern int   opt_mqtt_port;
+extern int opt_mqtt_port;
 extern char *opt_mqtt_topic;
 extern char *opt_zmq_endpoint;
-extern char *opt_cot_multicast;          /* "239.2.3.1:6969" or NULL */
-extern int   opt_web_port;
+extern char *opt_cot_multicast; /* "239.2.3.1:6969" or NULL */
+extern int opt_web_port;
 extern char *opt_station_id;
-extern char *opt_gpsd_endpoint;          /* "host:port"; NULL = disabled */
-extern char *opt_api_token;              /* bearer token for POST /api endpoints; NULL = unauthenticated */
-extern char *opt_pcap_path;              /* path to pcap file; NULL = disabled */
-extern char *opt_pcap_fifo;              /* path to pcap fifo; NULL = disabled */
-extern char *opt_psk_wordlist;           /* path to wordlist; NULL = disabled */
-extern char *opt_archive_dir;            /* JSONL archive directory; NULL = disabled */
-extern char *opt_geofence_file;          /* polygon file path; NULL = disabled */
-extern char *opt_announce_to;            /* fusion /api/sensors URL; NULL = disabled */
-extern char *opt_c2_dealer;              /* tcp://fusion:7009; NULL = HTTP-only */
-extern char *opt_zmq_curve_secret;       /* path to Z85 secret key file; sets server CURVE on PUB */
-extern char *opt_zmq_curve_keygen;       /* generate keypair to PATH (.pub written alongside) and exit */
-extern uint32_t opt_station_t_acc_ns;    /* self-reported clock-discipline class in ns; default 1e6 (NTP) */
+extern char *opt_gpsd_endpoint; /* "host:port"; NULL = disabled */
+extern char *opt_api_token;     /* bearer token for POST /api endpoints; NULL =
+                                   unauthenticated */
+extern char *opt_pcap_path;     /* path to pcap file; NULL = disabled */
+extern char *opt_pcap_fifo;     /* path to pcap fifo; NULL = disabled */
+extern char *opt_psk_wordlist;  /* path to wordlist; NULL = disabled */
+extern char *opt_archive_dir;   /* JSONL archive directory; NULL = disabled */
+extern char *opt_geofence_file; /* polygon file path; NULL = disabled */
+extern char *opt_announce_to;   /* fusion /api/sensors URL; NULL = disabled */
+extern char *opt_c2_dealer;     /* tcp://fusion:7009; NULL = HTTP-only */
+extern char *opt_zmq_curve_secret; /* path to Z85 secret key file; sets server
+                                      CURVE on PUB */
+extern char *opt_zmq_curve_keygen; /* generate keypair to PATH (.pub written
+                                      alongside) and exit */
+extern uint32_t opt_station_t_acc_ns; /* self-reported clock-discipline class in
+                                         ns; default 1e6 (NTP) */
 
-int  options_parse(int argc, char **argv);
+int options_parse(int argc, char **argv);
 void options_print_help(const char *prog);
 
 #endif /* OPTIONS_H */

--- a/usrp.c
+++ b/usrp.c
@@ -26,7 +26,6 @@ extern volatile sig_atomic_t running;
 extern pid_t self_pid;
 extern double samp_rate;
 extern double center_freq;
-extern int usrp_gain_val;
 extern int verbose;
 
 extern void push_samples(sample_buf_t *buf);


### PR DESCRIPTION
Fixes gain setting for BladeRF, Airspy, USRP

parser now uses _gain_val rather than old _gain or _gain_db

I have tested with a BladeRF and an Airspy Mini. Have not yet tested with USRP, but the issue seems to have persisted to that backend as well

