### PR TITLE
channelizer: fix RF window check for full-band PFB

### DIFF
--- a/channelizer.c
+++ b/channelizer.c
@@ -190,12 +190,14 @@ int channelizer_add_channel(channelizer_t *c, const channel_cfg_t *cfg)
     int b_signed = (int)round(offset / (double)cfg->bw_hz);
     int bin = ((b_signed % M) + M) % M;
 
-    /* Sanity: the channel must actually land within the FFT's frequency
-     * window; channels outside would alias. The PFB's output bin spans
-     * ±samp_rate/2 around bin_0_freq, so any channel within that range
-     * is reachable. */
-    if (offset < -((double)c->samp_rate * 0.5) ||
-        offset >  ((double)c->samp_rate * 0.5)) {
+    /* Sanity: require the channel center to fall inside the SDR RF window.
+     * offset above is relative to bin_0_freq for bin assignment, not relative
+     * to the SDR center, so do not compare it to +/- samp_rate/2 here. */
+
+    double rf_lo = (double)c->f_center - (double)c->samp_rate * 0.5;
+    double rf_hi = (double)c->f_center + (double)c->samp_rate * 0.5;
+
+    if ((double)cfg->f_hz < rf_lo || (double)cfg->f_hz > rf_hi) {
         if (verbose)
             fprintf(stderr, "channelizer: channel %.3f MHz outside Nyquist window\n",
                     (double)cfg->f_hz / 1e6);


### PR DESCRIPTION
This fixes the channelizer rejecting the upper half of a full-band complex IQ capture.

Repro before the patch:

./meshtastic-sniffer --bladerf --region=US --presets=LongFast \
  --rate=26000000 --center=915000000 \
  --keys=default --web=8888 -v

Before:
- RF window printed correctly as 902.000 .. 928.000 MHz
- PFB group was created with M=104
- Channels above 915.125 MHz were rejected as "outside Nyquist window"
- Result: LONG_FAST configured only 53/104 slots

Cause:
The bounds check compared an offset relative to grp->bin_0_freq against +/- samp_rate/2. For a PFB bin0 at 902.125 MHz, that incorrectly rejects the upper half of the valid RF window.

Fix:
Check cfg->f_hz against the actual SDR RF window:
center - sample_rate/2 through center + sample_rate/2.

After:
Same command configures all 104/104 LongFast slots across 902.125 MHz through 927.875 MHz.