### PR TITLE
vita49: adopt sample-rate, RF freq, and IQ format from IF-context

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ CMake prints which backends it found. Run `./meshtastic-sniffer --list` to confi
 # Replay an IQ file:
 ./meshtastic-sniffer --file=capture.cf32 --keys=default
 
-# Network IQ in (VITA-49):
+# Network IQ in (VITA-49): rate, RF freq, and IQ format are taken from the
+# sender's IF-context packets -- add --iq-format only if the sender omits it.
 ./meshtastic-sniffer --vita49=4991 --keys=default
 
 # List attached SDRs:
@@ -144,7 +145,7 @@ The number of channels demodulated at once is set by the SDR's analog bandwidth 
 | Airspy R2 / Mini | 10 MHz | One BW group + adjacent presets |
 | RTL-SDR (R820T) | 2.0 MHz | One BW group, ~8 LongFast slots |
 | SoapySDR (LimeSDR, PlutoSDR, ...) | varies | Per-device |
-| VITA-49 / VRT (network) | varies | Sample rate + freq from the IF-context packets |
+| VITA-49 / VRT (network) | varies | Sample rate, freq + IQ format from the IF-context packets |
 | IQ file | — | `.sigmf-meta` sibling auto-loads rate/freq/format |
 
 `--list` enumerates everything attached.

--- a/main.c
+++ b/main.c
@@ -1636,14 +1636,23 @@ static uint32_t backend_default_rate(sdr_backend_t b)
 
 static void resolve_rf_defaults(void)
 {
-    /* User-specified rate wins; otherwise pick from the backend table. */
+    /* Precedence: an explicit CLI flag wins; otherwise keep any value the
+     * VITA-49 listener already adopted from an IF-context packet (it writes
+     * samp_rate / center_freq directly before we run); only then fall back to
+     * the backend/region default. The bare clobber here used to wipe the
+     * adopted context rate back to the backend default (0 for VITA-49),
+     * turning a context-supplied stream into a fatal "rate not set" error. */
     if (opt_sample_rate) {
         samp_rate = (double)opt_sample_rate;
-    } else {
+    } else if (samp_rate == 0.0) {
         samp_rate = (double)backend_default_rate(opt_sdr_backend);
     }
-    center_freq = (double)opt_center_freq_hz;
-    if (center_freq != 0.0) return;
+
+    if (opt_center_freq_hz != 0) {
+        center_freq = (double)opt_center_freq_hz;
+        return;
+    }
+    if (center_freq != 0.0) return;  /* adopted from VITA-49 context */
 
     /* Derive: place center at the midpoint of the (region, preset) coverage. */
     const mesh_region_t *r = mesh_lookup_region(opt_region ? opt_region : "US");

--- a/main.c
+++ b/main.c
@@ -3102,7 +3102,7 @@ static int run_live(void)
                 opt_sample_rate = (uint32_t)m.sample_rate;
             if (m.have_frequency && opt_center_freq_hz == 0)
                 opt_center_freq_hz = (uint64_t)m.frequency_hz;
-            if (m.have_datatype && iq_format == FMT_CI8)
+            if (m.have_datatype && !opt_iq_format_set)
                 iq_format = m.datatype;
             fprintf(stderr, "sigmf: loaded metadata for %s "
                             "(rate=%g freq=%g datatype=%d)\n",

--- a/options.c
+++ b/options.c
@@ -68,6 +68,7 @@ int           opt_extra_freq_count    = 0;
 /* SDR / file input */
 char       *opt_input_file = NULL;
 iq_format_t iq_format      = FMT_CI8;
+bool        opt_iq_format_set = false;
 
 /* Per-backend gain controls.
  *
@@ -176,15 +177,18 @@ void options_print_help(const char *prog)
         "  --vita49=[BIND:]PORT   listen for VITA-49 (VRT) UDP. PORT is required;\n"
         "                         BIND defaults to 0.0.0.0. Sender side must use:\n"
         "                           - VRT signal-data packets (network byte order, big-endian)\n"
-        "                           - matching --iq-format (ci8 default, ci16, or cf32)\n"
+        "                           - an --iq-format matching the payload, unless the\n"
+        "                             sender's IF-context declares the payload format\n"
         "                         VRL wrapper ('VRLP') is auto-detected (optional).\n"
-        "                         IF-context packets are auto-adopted: sample_rate (Q44.20)\n"
-        "                         and RF freq override missing CLI values, so a sender\n"
-        "                         that emits context can run with bare --vita49=PORT.\n"
+        "                         IF-context packets are auto-adopted: sample_rate (Q44.20),\n"
+        "                         RF freq, and data-packet payload format override missing\n"
+        "                         CLI values, so a sender that emits context can run with\n"
+        "                         bare --vita49=PORT.\n"
         "  --file=PATH            replay IQ file\n"
         "  --iq-format=FMT        cs8 (default) | cs16 | cf32. Used for raw file replay\n"
-        "                         AND for the VITA-49 payload format -- the sender's\n"
-        "                         sample type must match.\n"
+        "                         AND for the VITA-49 payload format. For VITA-49 this is\n"
+        "                         only needed when the sender's context omits the payload\n"
+        "                         format; an explicit value here always wins.\n"
         "\n"
         "RF:\n"
         "  --center=HZ            center frequency (default: region-derived)\n"
@@ -491,6 +495,7 @@ int options_parse(int argc, char **argv)
             else if (!strcasecmp(optarg, "cs16") || !strcasecmp(optarg, "ci16")) iq_format = FMT_CI16;
             else if (!strcasecmp(optarg, "cf32") || !strcasecmp(optarg, "fc32")) iq_format = FMT_CF32;
             else { fprintf(stderr, "unknown --iq-format=%s\n", optarg); return 2; }
+            opt_iq_format_set = true;
             break;
 
         case O_CENTER:  opt_center_freq_hz = strtoull(optarg, NULL, 10); break;

--- a/options.h
+++ b/options.h
@@ -115,6 +115,7 @@ extern int          opt_extra_freq_count;
 /* SDR / file input */
 extern char       *opt_input_file;       /* IQ file path for FILE backend */
 extern iq_format_t iq_format;            /* FMT_CI8 / FMT_CI16 / FMT_CF32 */
+extern bool        opt_iq_format_set;    /* true if --iq-format given on CLI */
 
 /* Per-backend gain controls */
 extern int  hackrf_lna_gain;             /* 0..40 step 8 */

--- a/vita49.c
+++ b/vita49.c
@@ -140,26 +140,35 @@ static void vrt_handle_context(const uint8_t *vrt, size_t vrt_len,
     if (have_sr) {
         fprintf(stderr, "vita49: context reports sample_rate=%.0f Hz\n",
                 ctx_samp_rate);
-        if (samp_rate == 0.0 || opt_sample_rate == 0) {
+        if (opt_sample_rate == 0) {
             /* User didn't set --rate; adopt the context value so the
-             * channelizer comes up correctly without operator intervention. */
+             * channelizer comes up correctly without operator intervention.
+             * Test against opt_sample_rate, not samp_rate: this runs before
+             * resolve_rf_defaults(), so samp_rate is still 0 here regardless
+             * of any --rate the user passed. */
             samp_rate = ctx_samp_rate;
             fprintf(stderr, "vita49: adopting sample_rate from context\n");
-        } else if (ctx_samp_rate - samp_rate > 1.0 || samp_rate - ctx_samp_rate > 1.0)
-            fprintf(stderr, "vita49: WARNING: source sample rate %.0f Hz "
-                    "differs from -r %.0f Hz\n", ctx_samp_rate, samp_rate);
+        } else {
+            double cli = (double)opt_sample_rate;
+            if (ctx_samp_rate - cli > 1.0 || cli - ctx_samp_rate > 1.0)
+                fprintf(stderr, "vita49: WARNING: source sample rate %.0f Hz "
+                        "differs from -r %.0f Hz\n", ctx_samp_rate, cli);
+        }
     }
 
     if (have_rf) {
         fprintf(stderr, "vita49: context reports rf_freq=%.0f Hz\n",
                 rf_freq_hz);
-        if (center_freq == 0.0 || opt_center_freq_hz == 0) {
+        if (opt_center_freq_hz == 0) {
             center_freq = rf_freq_hz;
             fprintf(stderr, "vita49: adopting center_freq from context\n");
-        } else if (rf_freq_hz - center_freq > 1.0 || center_freq - rf_freq_hz > 1.0)
-            fprintf(stderr, "vita49: WARNING: source RF freq %.0f Hz "
-                    "differs from center_freq %.0f Hz\n",
-                    rf_freq_hz, center_freq);
+        } else {
+            double cli = (double)opt_center_freq_hz;
+            if (rf_freq_hz - cli > 1.0 || cli - rf_freq_hz > 1.0)
+                fprintf(stderr, "vita49: WARNING: source RF freq %.0f Hz "
+                        "differs from center_freq %.0f Hz\n",
+                        rf_freq_hz, cli);
+        }
     }
 }
 

--- a/vita49.c
+++ b/vita49.c
@@ -5,7 +5,8 @@
  * VITA 49 (VRT) UDP input - receives IQ samples via VRT signal data packets
  *
  * Supports VRL-wrapped and unwrapped VRT packets, IF context extraction
- * (sample rate, RF frequency), and all three IQ formats (ci8, ci16, cf32).
+ * (sample rate, RF frequency, data-packet payload format), and all three IQ
+ * formats (ci8, ci16, cf32).
  *
  */
 
@@ -62,6 +63,7 @@ static uint64_t read_be64(const uint32_t *p)
 #define CIF_REF_LEVEL       (1u << 24)
 #define CIF_GAIN            (1u << 23)
 #define CIF_SAMPLE_RATE     (1u << 21)
+#define CIF_DATA_FORMAT     (1u << 15)
 
 static const struct { uint32_t bit; unsigned words; } cif_fields[] = {
     { 1u << 31, 1 },           /* context field change indicator */
@@ -75,7 +77,35 @@ static const struct { uint32_t bit; unsigned words; } cif_fields[] = {
     { CIF_GAIN,         1 },  /* gain */
     { 1u << 22, 1 },          /* over-range count */
     { CIF_SAMPLE_RATE,  2 },  /* sample rate */
+    { 1u << 20, 2 },          /* timestamp adjustment */
+    { 1u << 19, 1 },          /* timestamp calibration time */
+    { 1u << 18, 1 },          /* temperature */
+    { 1u << 17, 2 },          /* device identifier */
+    { 1u << 16, 1 },          /* state and event indicators */
+    { CIF_DATA_FORMAT,  2 },  /* data packet payload format */
 };
+
+static const char *iq_format_name(iq_format_t f)
+{
+    return f == FMT_CF32 ? "cf32" : f == FMT_CI16 ? "cs16" : "cs8";
+}
+
+/* Decode the first word of a VITA-49.0 Data Packet Payload Format field into
+ * one of our three supported IQ types. Returns 1 on a recognized mapping,
+ * 0 otherwise (caller leaves the format untouched). */
+static int payload_format_to_iq(uint32_t fw, iq_format_t *out)
+{
+    unsigned data_item_format = (fw >> 24) & 0x1F;  /* bits 28..24 */
+    unsigned packing_size     = ((fw >> 6) & 0x3F) + 1;  /* item packing field size, bits/component */
+
+    if (data_item_format == 0x1E) {        /* IEEE-754 single-precision float */
+        if (packing_size == 32) { *out = FMT_CF32; return 1; }
+    } else if (data_item_format == 0x00) { /* signed fixed-point */
+        if (packing_size == 8)  { *out = FMT_CI8;  return 1; }
+        if (packing_size == 16) { *out = FMT_CI16; return 1; }
+    }
+    return 0;
+}
 
 static void vrt_handle_context(const uint8_t *vrt, size_t vrt_len,
                                 int *ctx_logged)
@@ -109,6 +139,9 @@ static void vrt_handle_context(const uint8_t *vrt, size_t vrt_len,
     int have_rf = 0;
     double ctx_samp_rate = 0;
     int have_sr = 0;
+    iq_format_t ctx_fmt = FMT_CI8;
+    int have_fmt = 0;        /* payload-format field present and recognized */
+    int fmt_unsupported = 0; /* field present but not one of our three types */
 
     for (unsigned i = 0; i < sizeof(cif_fields)/sizeof(cif_fields[0]); i++) {
         if (!(cif0 & cif_fields[i].bit))
@@ -125,12 +158,16 @@ static void vrt_handle_context(const uint8_t *vrt, size_t vrt_len,
             uint64_t val = read_be64(&words[off_w]);
             ctx_samp_rate = (double)(int64_t)val / (1LL << 20);
             have_sr = 1;
+        } else if (cif_fields[i].bit == CIF_DATA_FORMAT) {
+            uint32_t fw = ntohl(words[off_w]);
+            if (payload_format_to_iq(fw, &ctx_fmt)) have_fmt = 1;
+            else fmt_unsupported = 1;
         }
 
         off_w += cif_fields[i].words;
     }
 
-    if (!have_rf && !have_sr)
+    if (!have_rf && !have_sr && !have_fmt && !fmt_unsupported)
         return;
 
     if (*ctx_logged)
@@ -169,6 +206,25 @@ static void vrt_handle_context(const uint8_t *vrt, size_t vrt_len,
                         "differs from center_freq %.0f Hz\n",
                         rf_freq_hz, cli);
         }
+    }
+
+    if (have_fmt) {
+        fprintf(stderr, "vita49: context reports payload format=%s\n",
+                iq_format_name(ctx_fmt));
+        if (!opt_iq_format_set) {
+            /* User didn't pin --iq-format; adopt the context value so the
+             * sample type matches the sender without operator intervention. */
+            iq_format = ctx_fmt;
+            fprintf(stderr, "vita49: adopting payload format from context\n");
+        } else if (ctx_fmt != iq_format) {
+            fprintf(stderr, "vita49: WARNING: source payload format %s "
+                    "differs from --iq-format %s\n",
+                    iq_format_name(ctx_fmt), iq_format_name(iq_format));
+        }
+    } else if (fmt_unsupported && !opt_iq_format_set) {
+        fprintf(stderr, "vita49: WARNING: context payload format is not one of "
+                "cs8/cs16/cf32; keeping --iq-format %s\n",
+                iq_format_name(iq_format));
     }
 }
 


### PR DESCRIPTION
NOTE: I implemented this with Claude Code, but tested it myself against real V49 streams and SigMF files.

## Summary

This PR adds the ability for the datatype, frequency, and sample rate to be automatically determined using the context packet for VITA-49 streams. You can now use `--vita49=PORT` as your only CLI switch when ingesting V49.

If values are specified by the user anyway, they will override the context packets. This logic was also added to `.sigmf` file input for consistency.

There are two commits.

### 1. Honor IF-context rate/freq in default resolution

`resolve_rf_defaults()` unconditionally re-set `samp_rate` and `center_freq` from the CLI option vars, clobbering values the VITA-49 listener thread had already adopted from IF-context packets. This had two effects:

- With a bare `--vita49=PORT` (no `--rate`), the adopted sample rate was reset to the backend default, which is `0` for VITA-49, producing a fatal `ERROR: sample rate not set`. So a context-emitting sender could not actually run with `--vita49=PORT` as the help text implied.
- The context RF center frequency was silently discarded in favor of the region midpoint whenever `--center` was omitted, giving an off-center capture with no error.

Precedence is now explicit CLI flag, then value adopted from IF-context, then backend or region default. This also fixes a dead mismatch-warning branch that compared against the not-yet-resolved global (always `0` at parse time), so the "source rate differs from -r" warning never fired.

### 2. Auto-adopt IQ payload format from IF-context

Parses the VITA-49.0 Data Packet Payload Format field (CIF0 bit 15) and maps it to `cs8`, `cs16`, or `cf32`, alongside the existing rate and frequency adoption.

- Extends the CIF0 field table through bit 15 so the field offset is computed correctly. The timestamp adjustment, timestamp calibration, temperature, device identifier, and state/event indicator fields all sit between sample-rate and payload-format.
- Decodes data-item-format plus item-packing-size: signed-fixed 8/16 maps to cs8/cs16, IEEE-754 single maps to cf32. Unrecognized encodings warn and fall back to the CLI or default rather than guessing.
- Adds an `opt_iq_format_set` flag so an explicit `--iq-format` always wins over context, with a mismatch warning. The same flag replaces an `iq_format == FMT_CI8` proxy in the SigMF path that could not tell an explicit `--iq-format=cs8` from the default, which meant a `.sigmf-meta` could previously override a deliberate `--iq-format=cs8` without warning.